### PR TITLE
closes: 102 evaluate arg types of typedicts required and notrequired types instead of origin types

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ ujson>=3.0.0
 pytest==6.2.5
 pytest-cov>=2.10.0
 codecov
+typing-extensions>=4.4.0

--- a/strongtyping/strong_typing_utils.py
+++ b/strongtyping/strong_typing_utils.py
@@ -265,7 +265,7 @@ def checking_typing_iterable(arg: Any, possible_types: tuple, *args, **kwargs):
 
 def checking_typing_typedict_values(args: dict, required_types: dict, total: bool):
     if total:
-        return all(check_type(args[key], val) for key, val in required_types.items())
+        return all(check_type(args.get(key), val) for key, val in required_types.items())
     fields_to_check = {key: val for key, val in required_types.items() if key in args}
     return all(check_type(args[key], val) for key, val in fields_to_check.items())
 
@@ -281,6 +281,16 @@ def checking_typing_typeddict(arg: Any, possible_types: Any, *args, **kwargs):
         if not all(field in arg for field in required_fields):
             return False
     return checking_typing_typedict_values(arg, required_fields, total)
+
+
+def checking_typing_typeddict_required(arg: Any, possible_types: Any, *args, **kwargs):
+    return check_type(arg, possible_types[0])
+
+
+def checking_typing_typeddict_notrequired(arg: Any, possible_types: Any, *args, **kwargs):
+    if arg is None:
+        return True
+    return check_type(arg, possible_types[0])
 
 
 def module_checking_typing_list(arg: Any, possible_types: Any):
@@ -459,6 +469,14 @@ def check_type(argument, type_of, mro=False, **kwargs):
             return argument.__class__.__name__ == type_of
         elif origin_name in ("_typeddictmeta", "matchtypeddict", "typeddict"):
             return checking_typing_typeddict(argument, get_possible_types(type_of, "typeddict"))
+        elif origin_name == "required":
+            return checking_typing_typeddict_required(
+                argument, get_possible_types(type_of, origin_name)
+            )
+        elif origin_name == "notrequired":
+            return checking_typing_typeddict_notrequired(
+                argument, get_possible_types(type_of, origin_name)
+            )
         elif mro:
             if origin_name == "union":
                 possible_types = get_possible_types(type_of)

--- a/strongtyping/tests/test_typedict.py
+++ b/strongtyping/tests/test_typedict.py
@@ -253,5 +253,34 @@ def test_typeddict_with_not_required_cannot_before_required():
         Movie(title="Prisoner of azkaban", regisseur="Alfonso Cuarón", year=2004)
 
 
+def test_typeddict_with_required_and_not_required_and_sub_typeddict():
+    from typing_extensions import TypedDict
+
+    @match_class_typing
+    class Movie(TypedDict):
+        title: str
+        year: NotRequired[int]
+
+    @match_class_typing
+    class Additional(TypedDict):
+        name: str
+        val: NotRequired[str]
+
+    @match_class_typing
+    class Regisseur(TypedDict):
+        name: str
+        movie: Required[dict[Movie]]
+        year: Required[int]
+        info: NotRequired[dict[Additional]]
+
+    assert Regisseur(name="Alfonso Cuarón", movie=Movie(title="Hallow"), year=2004)
+
+    with pytest.raises(TypeMisMatch):
+        Regisseur(name="Alfonso Cuarón", movie=Movie, year=2004)
+
+    with pytest.raises(TypeMisMatch):
+        Regisseur(name="Alfonso Cuarón", year=2004)
+
+
 if __name__ == "__main__":
     pytest.main(["-vv", "-s", __file__])

--- a/strongtyping/tests/test_typedict.py
+++ b/strongtyping/tests/test_typedict.py
@@ -4,7 +4,6 @@
 @created: 03.06.21
 @author: felix
 """
-import sys
 from typing import List, Union
 
 import pytest
@@ -13,7 +12,6 @@ from strongtyping.strong_typing import match_class_typing, match_typing
 from strongtyping.strong_typing_utils import TypeMisMatch, ValidationError
 
 
-@pytest.mark.skipif(sys.version_info.minor < 8, reason="TypedDict only available since 3.8")
 def test_typedict():
     from typing import TypedDict
 
@@ -29,7 +27,6 @@ def test_typedict():
         SalesSummary({"sales": "Foo", "country": 10, "product_codes": [1, 2, 3]})
 
 
-@pytest.mark.skipif(sys.version_info.minor < 8, reason="TypedDict only available since 3.8")
 def test_typedict_with_total():
     from typing import TypedDict
 
@@ -45,7 +42,6 @@ def test_typedict_with_total():
         SalesSummary({"sales": "Foo", "product_codes": [1, 2, 3]})
 
 
-@pytest.mark.skipif(sys.version_info.minor < 8, reason="TypedDict only available since 3.8")
 def test_typedict_with_validator():
     from typing import TypedDict
 
@@ -76,7 +72,6 @@ def test_typedict_with_validator():
         cluster({"sales": 10, "country": "Europe", "product_codes": list(range(10))})
 
 
-@pytest.mark.skipif(sys.version_info.minor < 8, reason="TypedDict only available since 3.8")
 def test_typedict_with_validator_and_total():
     from typing import TypedDict
 
@@ -107,7 +102,6 @@ def test_typedict_with_validator_and_total():
         cluster({"product_codes": list(range(10))})
 
 
-@pytest.mark.skipif(sys.version_info.minor < 8, reason="TypedDict only available since 3.8")
 def test_use_typed_dict_total_true_class_as_function_parameter_to_validate():
     from typing import TypedDict
 
@@ -128,7 +122,6 @@ def test_use_typed_dict_total_true_class_as_function_parameter_to_validate():
         move_to({"y": 2.1})
 
 
-@pytest.mark.skipif(sys.version_info.minor < 8, reason="TypedDict only available since 3.8")
 def test_use_typed_dict_total_false_class_as_function_parameter_to_validate():
     from typing import TypedDict
 
@@ -146,7 +139,6 @@ def test_use_typed_dict_total_false_class_as_function_parameter_to_validate():
     assert move_to({"x": 1.0, "y": 2.0})
 
 
-@pytest.mark.skipif(sys.version_info.minor < 8, reason="TypedDict only available since 3.8")
 def test_nested_typeddicts():
     from typing import TypedDict
 
@@ -174,7 +166,6 @@ def test_nested_typeddicts():
         make_move({"position": {"x": 1.0, "y": 2.0, "z": 0.25}})
 
 
-@pytest.mark.skipif(sys.version_info.minor < 8, reason="TypedDict only available since 3.8")
 def test_calling_a_typeddict_class_without_dict():
     from typing import TypedDict
 


### PR DESCRIPTION
Add support for Required | NotRequired from typing-extension