### PR TITLE
fix: add support for PEP 604 union syntax (X | Y)

### DIFF
--- a/docs/match_typing.md
+++ b/docs/match_typing.md
@@ -143,6 +143,7 @@ The current version of `strongtyping` supports:
     - List
     - Tuple
     - Union also nested ( Tuple[Union[str, int], Union[list, tuple]] )
+    - PEP 604 union syntax ( str | int | None )
     - Any
     - Dict
     - Set

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -13,6 +13,7 @@
 ### New Features
 
 - Added support for Python version 3.13 as reflected in the README updates. Now users are aware of the extended compatibility with newer Python versions.
+- Added support for PEP 604 union syntax (X | Y) - Fixes compatibility issues with types.UnionType introduced in Python 3.10+.
 
 ### Refactoring
 

--- a/strongtyping/strong_typing_utils.py
+++ b/strongtyping/strong_typing_utils.py
@@ -6,6 +6,7 @@
 """
 import inspect
 import os
+import types
 import typing
 from collections import deque
 from collections.abc import Callable, Iterable
@@ -440,6 +441,11 @@ def check_type(argument, type_of, mro=False, **kwargs):
             return checking_typing_json(argument, type_of, mro)
 
         if origin is typing.Union:
+            return checking_typing_union(
+                argument, get_possible_types(type_of, origin_name), mro, **kwargs
+            )
+        elif isinstance(type_of, types.UnionType):
+            # Handle PEP 604 union syntax (e.g., int | str)
             return checking_typing_union(
                 argument, get_possible_types(type_of, origin_name), mro, **kwargs
             )

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -36,6 +36,7 @@ from strongtyping.config import SEVERITY_LEVEL
 from strongtyping.strong_typing import match_class_typing, match_typing
 from strongtyping.strong_typing_utils import (
     TypeMismatch,
+    check_type,
     checking_typing_dict,
     checking_typing_json,
     checking_typing_list,
@@ -1292,6 +1293,63 @@ def test_typevar():
         concatenate(1, 2)
     with pytest.raises(TypeMismatch):
         concatenate(list("hello"), "world".split())
+
+
+def test_pep604_union_syntax():
+    """Test PEP 604 union syntax (X | Y) support"""
+    # Test basic union types
+    assert check_type("hello", str | int) is True
+    assert check_type(42, str | int) is True
+    assert check_type(3.14, str | int) is False
+    
+    # Test with None (Optional-like)
+    assert check_type([], list[str] | None) is True
+    assert check_type(None, list[str] | None) is True
+    assert check_type("not a list", list[str] | None) is False
+    
+    # Test complex nested types
+    assert check_type([1, 2, 3], list[int] | dict[str, int]) is True
+    assert check_type({"a": 1}, list[int] | dict[str, int]) is True  
+    assert check_type("neither", list[int] | dict[str, int]) is False
+    
+    # Test three-way union
+    assert check_type("text", str | int | list) is True
+    assert check_type(123, str | int | list) is True
+    assert check_type([1, 2, 3], str | int | list) is True
+    assert check_type({"not": "allowed"}, str | int | list) is False
+
+
+def test_pep604_vs_traditional_union():
+    """Test that PEP 604 and traditional Union work the same way"""
+    from typing import Union
+    
+    # Both should behave identically
+    pep604_type = str | int
+    traditional_type = Union[str, int]
+    
+    test_values = ["hello", 42, 3.14, [], None]
+    
+    for value in test_values:
+        pep604_result = check_type(value, pep604_type)
+        traditional_result = check_type(value, traditional_type)
+        assert pep604_result == traditional_result, f"Mismatch for {value}: PEP604={pep604_result}, Traditional={traditional_result}"
+
+
+@match_typing
+def test_pep604_with_decorators():
+    """Test PEP 604 union syntax works with @match_typing decorator"""
+    @match_typing
+    def process_value(x: str | int | None) -> str:
+        if x is None:
+            return "none"
+        return str(x)
+    
+    assert process_value("hello") == "hello"
+    assert process_value(42) == "42" 
+    assert process_value(None) == "none"
+    
+    with pytest.raises(TypeMismatch):
+        process_value([1, 2, 3])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes AttributeError when using types.UnionType objects introduced in Python 3.10+ with modern union syntax like `str | int`.

- Add types.UnionType handling in check_type function
- Add comprehensive tests for PEP 604 union syntax
- Update documentation to mention PEP 604 support
- Update release notes

🤖 Generated with [Claude Code](https://claude.ai/code)